### PR TITLE
ES6 update

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,0 @@
-module.exports = {
-    "extends": ["./node_modules/node-style-guide/.eslintrc"],
-    "installedESLint": true,
-};

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,78 @@
+{
+    "plugins": [],
+    "extends": [],
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "jsx": false
+        }
+    },
+    "env": {
+        "node": true
+    },
+    "rules": {
+        "array-bracket-spacing": [
+            2,
+            "never"
+        ],
+        "block-scoped-var": 2,
+        "brace-style": [
+            2,
+            "1tbs"
+        ],
+        "camelcase": 1,
+        "computed-property-spacing": [
+            2,
+            "never"
+        ],
+        "curly": 2,
+        "eol-last": 2,
+        "eqeqeq": [
+            2,
+            "smart"
+        ],
+        "max-depth": [
+            1,
+            3
+        ],
+        "max-len": [
+            1,
+            80
+        ],
+        "max-statements": [
+            1,
+            15
+        ],
+        "new-cap": 1,
+        "no-extend-native": 2,
+        "no-mixed-spaces-and-tabs": 2,
+        "no-trailing-spaces": 2,
+        "no-unused-vars": 1,
+        "no-use-before-define": [
+            2,
+            "nofunc"
+        ],
+        "object-curly-spacing": [
+            2,
+            "never"
+        ],
+        "quotes": [
+            2,
+            "single",
+            "avoid-escape"
+        ],
+        "semi": [
+            2,
+            "always"
+        ],
+        "keyword-spacing": [
+            2,
+            {
+                "before": true,
+                "after": true
+            }
+        ],
+        "space-unary-ops": 2
+    }
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,3 +1,16 @@
 {
-  "extends": "./node_modules/node-style-guide/.jshintrc"
+  "esversion": 6,
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "freeze": true,
+  "indent": 2,
+  "newcap": true,
+  "quotmark": "single",
+  "maxdepth": 3,
+  "maxstatements": 15,
+  "maxlen": 80,
+  "eqnull": true,
+  "funcscope": true,
+  "node": true
 }

--- a/beautify-solution.js
+++ b/beautify-solution.js
@@ -1,45 +1,46 @@
-var fs = require('fs');
-var path = require('path');
-var beautify = require('js-beautify').js;
-var beautifyOptions = JSON.parse(fs.readFileSync(path.join(__dirname,
+let fs = require('fs');
+let path = require('path');
+let beautify = require('js-beautify').js;
+let beautifyOptions = JSON.parse(fs.readFileSync(path.join(__dirname,
     '.jsbeautifyrc'), 'utf8'));
-var ignoreFolders = ['$Recycle.Bin', '.vscode', 'node_modules', 'typings',
+let ignoreFolders = ['$Recycle.Bin', 'node_modules', 'typings',
     '.git'
 ];
-var ignoreFiles = ['bundle.js'];
+let ignoreFiles = ['bundle.js'];
 /**
  * Gets all files where the extions is `.js` and the filename
  * does not start with a `.`. This method is recusive, so all
  * child folders are included in the search too.
  * @param  {} dirPath
  */
-var getJsFilesRecursive = function(dirPath) {
-    var files = [];
-    var dirContents = fs.readdirSync(dirPath);
-    for (var i = 0; i < dirContents.length; i++) {
-        var element = dirContents[i];
-        var elementStat = fs.statSync(path.join(dirPath, element));
+let getJsFilesRecursive = function(dirPath) {
+    let files = [];
+    let dirContents = fs.readdirSync(dirPath);
+    dirContents.forEach(element => {
+        let elementStat = fs.statSync(path.join(dirPath, element));
+        if (element.startsWith('.')) {
+            return;
+        }
         if (elementStat.isDirectory()) {
             if (ignoreFolders.indexOf(element) >= 0) {
-                continue;
+                return;
             }
-            files = files.concat(getJsFilesRecursive(path.join(dirPath, element)));
+            files = files.concat(getJsFilesRecursive(path.join(dirPath,
+                element)));
         } else {
-            if (ignoreFiles.indexOf(element) >= 0) {
-                continue;
-            }
-            if (element.startsWith('.') || !element.endsWith('.js')) {
-                continue;
+            if (ignoreFiles.indexOf(element) >= 0 || !element.endsWith(
+                    '.js')) {
+                return;
             }
             files.push(path.join(dirPath, element));
         }
-    }
+    });
     return files;
 };
-var files = getJsFilesRecursive(__dirname);
-for (var i = 0; i < files.length; i++) {
-    var filePath = files[i];
-    var beautifiedFileContents = beautify(fs.readFileSync(filePath, 'utf8'),
+
+let files = getJsFilesRecursive(__dirname);
+files.forEach(filePath => {
+    let beautifiedFileContents = beautify(fs.readFileSync(filePath, 'utf8'),
         beautifyOptions);
     fs.writeFileSync(filePath, beautifiedFileContents, 'utf8');
-}
+});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "browserify": "^11.0.0",
     "eslint": "^3.1.1",
-    "node-style-guide": "^1.0.0",
     "require-globify": "^1.2.1",
     "watchify": "^3.3.0",
     "jshint": "2.9.*"


### PR DESCRIPTION
Updates linting to support ES6. 

I had to make the "node-style-guide" module rules static, as it had a rule name which was deprecated and eslint would always show a warning. The package doesn't look to be updated frequently (only ever one version released), so I don't think this is going to cause an issue with missing future updates.

Updated beautify-solution.js to ES6.
